### PR TITLE
Make it compatible with GLI-2.

### DIFF
--- a/bin/planet
+++ b/bin/planet
@@ -2,6 +2,7 @@
 
 require 'gli'
 require 'planet'
+require 'fileutils'
 
 include GLI::App
 


### PR DESCRIPTION
GLI-2 tells you to use just "run(ARGV)", so I changed the executable to do that, otherwise it wouldn't work if someone tried to use it today with the latest version of GLI.
