### PR TITLE
Create PlanetPostImporter and let it run a block after initializing a Planet and fetched all posts

### DIFF
--- a/bin/planet
+++ b/bin/planet
@@ -49,27 +49,20 @@ desc 'Parses planet.yml file for blogs and generates their posts in Jekyll compl
 command :generate do |c|
 
   c.action do |global_options,options,args|
-    conf = YAML.load_file('planet.yml')
 
-    @planet = Planet.new(
-      config: conf.fetch('planet', {}),
-      blogs:  conf.fetch('blogs',  [])
-    )
+    PlanetPostImporter.import('planet.yml') do |planet|
 
-    @planet.aggregate
+      posts_dir = planet.config.fetch('posts_directory', 'source/_posts/')
+      FileUtils.mkdir_p(posts_dir)
+      puts "=> Writing #{ planet.posts.size } posts to the #{ posts_dir } directory."
+  
+      planet.posts.each do |post|
+        file_name = posts_dir + post.file_name
+        File.open(file_name + '.markdown', "w+") { |f| f.write(post.to_s) }
+      end
 
-    # Take the first argument as the path
-    # for a ruby file in order to change
-    # the way the posts are imported.
-    # Use on your own risk.
-    unless args[0].blank?
-      require args[0]
-      puts '=> ** NOTICE **: Running custom PostImporter'
-    else
-      puts '=> Running default PostImporter'
     end
 
-    @planet.write_posts
   end
 end
 

--- a/lib/planet/importer.rb
+++ b/lib/planet/importer.rb
@@ -1,15 +1,13 @@
-class PostImporter
+class PlanetPostImporter
 
-  def self.import(planet)
-    posts_dir = planet.config.fetch('posts_directory', 'source/_posts/')
-    FileUtils.mkdir_p(posts_dir)
-    puts "=> Writing #{ planet.posts.size } posts to the #{ posts_dir } directory."
+  def self.import(config)
 
-    planet.posts.each do |post|
-      file_name = posts_dir + post.file_name
+    planet = Planet.new(config)
 
-      File.open(file_name + '.markdown', "w+") { |f| f.write(post.to_s) }
-    end
+    planet.aggregate
+
+    yield(planet)
+
   end
 
 end


### PR DESCRIPTION
Adding two things:
- The executable is now just an option to import blog posts, any project will be able to require the gem and use it on any Ruby project no matter how big, hard or twisted.
- Custom ways to use imported blog posts. The importer will take a block and pass the Planet loaded based on a config file.

That's it.

No tests.
