### PR TITLE
Fail gracefully when failed to fetch a blog

### DIFF
--- a/lib/planet/blog.rb
+++ b/lib/planet/blog.rb
@@ -26,8 +26,12 @@ class Planet
       parser = self.type ? @parsers.get_parser(self.type) : @parsers.get_parser_for(self.feed)
 
       # parser instances should mimick Feedzirra interface
-      feed = parser.fetch_and_parse(self.feed)
+      parser.fetch_and_parse(self.feed,
+                            :on_success => lambda { |url, feed| on_fetch_success(feed) },
+                            :on_failure => lambda { |url, response_code, response_header, response_body| puts "\t=> Failed to fetch #{url} with response_code: #{response_code}" })
+    end
 
+    def on_fetch_success(feed)
       self.name ||= feed.title || 'the source'
       self.url ||= feed.url
 


### PR DESCRIPTION
- Allows fetching other blogs when one feed is broken
- Using the Feedzirra api for the success and failure callbacks
