### PR TITLE
Adding ability to import posts only with whitelisted tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The planet.yml file contains the basic config options for planet. It consists of
 ```yaml
 planet:
     posts_directory: source/_posts/                 # => Posts text files will be written into this directory
-    templates_directory: source/_layouts/           # => Planet specific layouts will be saved here, I suggest that it matches your Octopress/Jekyll layout directory.
+    templates_directory: source/_layouts/       # => Planet specific layouts will be saved here, I suggest that it matches your Octopress/Jekyll layout directory.
+    whitelisted_tags: []                                   # => Only posts that are tagged with any of these tags will be imported
 
 blogs:
   - author: "Cubox"                                 # => Name that we will use as the author of this post (soon you wont have to specify this :)

--- a/bin/planet
+++ b/bin/planet
@@ -151,6 +151,7 @@ layout: post
 planet:
     posts_directory: source/_posts/
     templates_directory: source/_layouts/
+    whitelisted_tags: []
 
 blogs:
   # Bare minimum to get it working

--- a/lib/planet.rb
+++ b/lib/planet.rb
@@ -5,12 +5,13 @@ require 'planet/importer'
 
 class Planet
 
-  attr_accessor :config, :blogs
+  attr_accessor :config, :blogs, :whitelisted_tags
 
   def initialize(config_file_path)
     config_file = read_config_file(config_file_path)
     self.config = config_file[:planet]
     self.blogs  = config_file[:blogs]
+    self.whitelisted_tags  = self.config['whitelisted_tags']
   end
 
   def posts

--- a/lib/planet/blog.rb
+++ b/lib/planet/blog.rb
@@ -36,6 +36,7 @@ class Planet
       end
 
       feed.entries.each do |entry|
+        next unless whitelisted?(entry)
         content = if entry.content
                     self.sanitize_images(entry.content.strip)
                   elsif entry.summary
@@ -68,6 +69,13 @@ class Planet
       end
 
       html
+    end
+
+    def whitelisted?(entry)
+      return true if self.planet.whitelisted_tags.empty?
+      result = !(entry.categories & self.planet.whitelisted_tags).empty?
+      puts "\t=> Ignored post titled: #{entry.title} with categories: [#{entry.categories.join(', ')}]" unless result
+      result
     end
   end
 end


### PR DESCRIPTION
- This helps filter personal posts and posts that are inappropriate for
  the planet
- The whitelisted tags can be left empty to allow all posts
