### PR TITLE
The feedzirra gem name changed to feedjira

### DIFF
--- a/lib/planet/parsers.rb
+++ b/lib/planet/parsers.rb
@@ -1,4 +1,4 @@
-require 'feedzirra'
+require 'feedjira'
 require 'set'
 
 # Parsers class - manager for the feed parsers
@@ -44,7 +44,7 @@ class Planet::Parsers
   end
 
   # returns any parser that can handle this feeds' domain,
-  # defaults to Feedzirra if none available.
+  # defaults to Feedjira if none available.
   def get_parser_for(feed)
     feed_domain = URI(feed).host
 
@@ -52,7 +52,7 @@ class Planet::Parsers
       return parser if feed_domain.end_with? domain
     end
 
-    return Feedzirra::Feed # default generic parser
+    return Feedjira::Feed # default generic parser
   end
 end
 

--- a/planet.gemspec
+++ b/planet.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables << 'planet'
   s.add_runtime_dependency('gli')
-  s.add_runtime_dependency('feedzirra')
+  s.add_runtime_dependency('feedjira')
   s.add_runtime_dependency('mustache')
   s.add_runtime_dependency('box')
 end


### PR DESCRIPTION
The latest version of feedzirra was throwing a `RuntimeError` with the message that the project name has changed to feedjira.
