### PR TITLE
We should properly escape the author name in post front-matter

### DIFF
--- a/bin/planet
+++ b/bin/planet
@@ -153,7 +153,7 @@ __END__
 title: "{{ post_title }}"
 kind: article
 created_at: {{ post_date }}
-author: {{ author }}
+author: "{{ author }}"
 categories: {{ blog_categories }}
 tags: {{ blog_tags }}
 layout: post


### PR DESCRIPTION
Fixes issue #53. It turns out that the reason I didn't think the patch was working was that I had failed to run `planet update_templates`.