### PR TITLE
Switch to `reverse_markdown` instead of `sanitize_html`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ list of blogs and output them in a format suitable for usage with these amazing 
 
 ## Main Features
 
-* Parse blogs, save posts as plain text files, ready to use with Octopress/Jekyll.
+* Parse blogs, save posts as plain markdown files, ready to use with Octopress/Jekyll.
 * Dead easy to set up.
 * Can be used on a regular blog, to import posts from other blogs while maintaining proper credits to the original author.
 * Completely unobstrusive, will not mess up your Octopress or Jekyll set up by changing files around.
+* Imported posts are converted to markdown to sanitize HTML and achieve a uniform appearance.
 
 ## Basic Set Up
 

--- a/bin/planet
+++ b/bin/planet
@@ -142,10 +142,11 @@ exit run(ARGV)
 __END__
 @@ author
 
+{::options parse_block_html="true" /}
 <div class="author">
-  <img src="{{ image_url }}" style="width: 96px; height: 96;">
-  <span style="position: absolute; padding: 32px 15px;">
-    <i>Original post by <a href="{{ twitter_url }}">{{ author }}</a> - check out <a href="{{ blog_url }}">{{ blog_name }}</a></i>
+   <img src="{{ image_url }}" style="width: 96px; height: 96;">
+   <span style="position: absolute; padding: 32px 15px;">{% comment %}Remark that post_url refers to the *original* post url, not Jekyll's post_url variable. Moreover, planet.rb preprocesses the substitutions with Mustache.{% endcomment %}
+      <i>{% if "{{ post_url }}" != "" %}<a href="{{ post_url }}">Original post</a>{% else %}Original post{% endif %} by {% if "{{ twitter_url }}" != "" %}<a href="{{ twitter_url }}">{{ author }}</a>{% else %}{{ author }}{% endif %} &mdash; check out <a href="{{ blog_url }}">{{ blog_name }}</a>.</i>
   </span>
 </div>
 
@@ -157,6 +158,7 @@ created_at: {{ post_date }}
 author: "{{ author }}"
 categories: {{ blog_categories }}
 tags: {{ blog_tags }}
+orig_url: {{ post_url }}
 layout: post
 ---
 

--- a/bin/planet
+++ b/bin/planet
@@ -167,7 +167,6 @@ planet:
     posts_directory: source/_posts/
     templates_directory: source/_layouts/
     whitelisted_tags: []
-    sanitize_html: false
 
 blogs:
   # Bare minimum to get it working

--- a/bin/planet
+++ b/bin/planet
@@ -141,6 +141,7 @@ exit run(ARGV)
 
 __END__
 @@ author
+
 <div class="author">
   <img src="{{ image_url }}" style="width: 96px; height: 96;">
   <span style="position: absolute; padding: 32px 15px;">

--- a/lib/planet/blog.rb
+++ b/lib/planet/blog.rb
@@ -1,4 +1,4 @@
-require 'sanitize'
+require 'reverse_markdown'
 require 'planet/post'
 require 'planet/parsers'
 
@@ -70,9 +70,7 @@ class Planet
                     abort "=> No content found on entry"
                   end
 
-        if self.planet.config.fetch('sanitize_html', false)
-            content = Sanitize.fragment(content, Sanitize::Config::RELAXED)
-        end
+        content = ReverseMarkdown.convert(content, unknown_tags: :bypass)
 
         self.posts << @post = Post.new(
           title: entry.title.nil? ? self.name : entry.title,

--- a/lib/planet/post.rb
+++ b/lib/planet/post.rb
@@ -32,7 +32,7 @@ class Planet::Post
       blog_tags: self.blog.tags,
       post_url: self.url,
       twitter: self.blog.twitter,
-      twitter_url: "http://twitter.com/#{ self.blog.twitter }",
+      twitter_url: self.blog.twitter.to_s == '' ? '' : "http://twitter.com/#{ self.blog.twitter }",
       post_rss_data: self.rss_data,
       blog_rss_data: self.blog.rss_data
     }

--- a/planet.gemspec
+++ b/planet.gemspec
@@ -22,5 +22,5 @@ spec = Gem::Specification.new do |s|
   s.add_runtime_dependency 'mustache',  '~> 0.99',  '>= 0.99.6'
   s.add_runtime_dependency 'box',       '~> 0.1',   '>= 0.1.1'
   s.add_runtime_dependency 'stringex',  '~> 2.5',   '>= 2.5.2'
-  s.add_runtime_dependency 'sanitize',  '~> 3.0',   '>= 3.0.0'
+  s.add_runtime_dependency 'reverse_markdown',      '~> 1.0',  '>= 1.0.1'
 end


### PR DESCRIPTION
Using `sanitize_html` was causing formatting issues on imported content with
non-trivial formatting. For example, simply dropping tags caused blocks of the
form

```
<noscript>
    some blah blah blah
</noscript>
```

to be treated and formatted as code blocks, because markdown causes indented
content to be parsed as a code block. Similarly, when a post's entire content is
stored on a single line in the RSS feed, this causes unusual rendering side
effects when tags are deleted, again due to Markdown's convention of treating
continuous blocks of text as paragraphs.

Instead, we use `reverse_markdown` to convert the HTML to Markdown, thereby
preserving the content one cares about (bold/italic, images, tables, lists,
links, etc.), while stripping out the undesirable content (scripts, CSS, etc.).
This has so far proven to be more reliable than the previous HTML sanitization.
It has the added benefit that the entire site, including the aggregated content,
is styled identically.
